### PR TITLE
Better exception handling

### DIFF
--- a/src/main/java/com/cemonan/blog/config/RedisConfig.java
+++ b/src/main/java/com/cemonan/blog/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
 
 @Configuration
 public class RedisConfig {
@@ -16,6 +17,8 @@ public class RedisConfig {
 
     @Bean(name = "config.RedisConfig.getPool")
     public JedisPool getPool() {
-        return new JedisPool(host, Integer.parseInt(port));
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setJmxEnabled(false);
+        return new JedisPool(config, host, Integer.parseInt(port));
     }
 }

--- a/src/main/java/com/cemonan/blog/exception/AuthUserNotFoundException.java
+++ b/src/main/java/com/cemonan/blog/exception/AuthUserNotFoundException.java
@@ -1,6 +1,6 @@
 package com.cemonan.blog.exception;
 
-public class AuthUserNotFoundException extends RuntimeException {
+public class AuthUserNotFoundException extends Exception {
     public AuthUserNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/com/cemonan/blog/exception/CannotResolveApplicationPropertiesPathException.java
+++ b/src/main/java/com/cemonan/blog/exception/CannotResolveApplicationPropertiesPathException.java
@@ -1,6 +1,6 @@
 package com.cemonan.blog.exception;
 
-public class CannotResolveApplicationPropertiesPathException extends RuntimeException {
+public class CannotResolveApplicationPropertiesPathException extends Exception {
     public CannotResolveApplicationPropertiesPathException(String message) {
         super(message);
     }

--- a/src/main/java/com/cemonan/blog/exception/DALException.java
+++ b/src/main/java/com/cemonan/blog/exception/DALException.java
@@ -1,0 +1,7 @@
+package com.cemonan.blog.exception;
+
+public class DALException extends Exception {
+    public DALException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cemonan/blog/exception/ExceptionHandler.java
+++ b/src/main/java/com/cemonan/blog/exception/ExceptionHandler.java
@@ -81,6 +81,18 @@ public class ExceptionHandler extends ResponseEntityExceptionHandler {
         response.setTimestamp(new Date());
         response.setMessage("Internal server error");
 
-        return new ResponseEntity(response, HttpStatus.UNAUTHORIZED);
+        return new ResponseEntity(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public final ResponseEntity<Object> handleDALException(DALException ex, WebRequest request) {
+        ExceptionResponse response = new ExceptionResponse();
+
+        ex.printStackTrace();
+
+        response.setTimestamp(new Date());
+        response.setMessage("Internal server error");
+
+        return new ResponseEntity(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/cemonan/blog/exception/TokenNotFoundException.java
+++ b/src/main/java/com/cemonan/blog/exception/TokenNotFoundException.java
@@ -1,6 +1,6 @@
 package com.cemonan.blog.exception;
 
-public class TokenNotFoundException extends RuntimeException {
+public class TokenNotFoundException extends Exception {
     public TokenNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/com/cemonan/blog/exception/TokenNotProvidedException.java
+++ b/src/main/java/com/cemonan/blog/exception/TokenNotProvidedException.java
@@ -1,6 +1,6 @@
 package com.cemonan.blog.exception;
 
-public class TokenNotProvidedException extends RuntimeException {
+public class TokenNotProvidedException extends Exception {
     public TokenNotProvidedException(String message) {
         super(message);
     }

--- a/src/main/java/com/cemonan/blog/factory/TokenFactory.java
+++ b/src/main/java/com/cemonan/blog/factory/TokenFactory.java
@@ -1,10 +1,11 @@
 package com.cemonan.blog.factory;
 
 import com.cemonan.blog.domain.Token;
+import com.cemonan.blog.exception.DALException;
 
 import java.util.List;
 
 public interface TokenFactory {
-    Token create();
-    List<Token> create(int size);
+    Token create() throws DALException;
+    List<Token> create(int size) throws DALException;
 }

--- a/src/main/java/com/cemonan/blog/factory/TokenFactoryImpl.java
+++ b/src/main/java/com/cemonan/blog/factory/TokenFactoryImpl.java
@@ -25,8 +25,7 @@ public class TokenFactoryImpl implements TokenFactory {
     @Override
     public Token create() throws DALException {
         User user = userFactory.create();
-        Token token = authTokenRepository.create(user);
-        return token;
+        return authTokenRepository.create(user);
     }
 
     @Override

--- a/src/main/java/com/cemonan/blog/factory/TokenFactoryImpl.java
+++ b/src/main/java/com/cemonan/blog/factory/TokenFactoryImpl.java
@@ -2,6 +2,7 @@ package com.cemonan.blog.factory;
 
 import com.cemonan.blog.domain.Token;
 import com.cemonan.blog.domain.User;
+import com.cemonan.blog.exception.DALException;
 import com.cemonan.blog.repository.AuthTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -22,14 +23,14 @@ public class TokenFactoryImpl implements TokenFactory {
     }
 
     @Override
-    public Token create() {
+    public Token create() throws DALException {
         User user = userFactory.create();
         Token token = authTokenRepository.create(user);
         return token;
     }
 
     @Override
-    public List<Token> create(int size) {
+    public List<Token> create(int size) throws DALException {
         List<Token> tokens = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             tokens.add(create());

--- a/src/main/java/com/cemonan/blog/repository/AuthTokenRepository.java
+++ b/src/main/java/com/cemonan/blog/repository/AuthTokenRepository.java
@@ -2,15 +2,16 @@ package com.cemonan.blog.repository;
 
 import com.cemonan.blog.domain.Token;
 import com.cemonan.blog.domain.User;
+import com.cemonan.blog.exception.DALException;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
 @Component
 public interface AuthTokenRepository {
-    Token getTokenByUUID(UUID uuid);
-    Token create(User user);
-    User getUserByToken(Token token);
-    Token update(Token token);
-    void delete(Token token);
+    Token getTokenByUUID(UUID uuid) throws DALException;
+    Token create(User user) throws DALException;
+    User getUserByToken(Token token) throws DALException;
+    Token update(Token token) throws DALException;
+    void delete(Token token) throws DALException;
 }

--- a/src/main/java/com/cemonan/blog/repository/AuthTokenRepositoryImpl.java
+++ b/src/main/java/com/cemonan/blog/repository/AuthTokenRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.cemonan.blog.repository;
 import com.cemonan.blog.dao.UserDao;
 import com.cemonan.blog.domain.Token;
 import com.cemonan.blog.domain.User;
+import com.cemonan.blog.exception.DALException;
 import com.cemonan.blog.lib.redis.RedisConnector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +30,7 @@ public class AuthTokenRepositoryImpl implements AuthTokenRepository{
     }
 
     @Override
-    public Token getTokenByUUID(UUID uuid) {
+    public Token getTokenByUUID(UUID uuid) throws DALException {
         Jedis connection = null;
         try {
             connection = redisConnector.getConnection();
@@ -47,16 +48,17 @@ public class AuthTokenRepositoryImpl implements AuthTokenRepository{
 
             return  token;
 
-        } catch (RuntimeException ex) {
-            ex.printStackTrace();
+        } catch (Exception ex) {
+            DALException dalException = new DALException(ex.getMessage());
+            dalException.setStackTrace(ex.getStackTrace());
+            throw dalException;
         } finally {
             closeConnection(connection);
         }
-        return null;
     }
 
     @Override
-    public Token create(User user) {
+    public Token create(User user) throws DALException {
         Jedis connection = null;
         try {
             connection = redisConnector.getConnection();
@@ -68,16 +70,17 @@ public class AuthTokenRepositoryImpl implements AuthTokenRepository{
             connection.setex(getKeyByToken(token), Long.valueOf(DEFAULT_EXPIRATION), user.getId().toString());
 
             return token;
-        } catch (RuntimeException ex) {
-            ex.printStackTrace();
+        } catch (Exception ex) {
+            DALException dalException = new DALException(ex.getMessage());
+            dalException.setStackTrace(ex.getStackTrace());
+            throw dalException;
         } finally {
             closeConnection(connection);
         }
-        return null;
     }
 
     @Override
-    public User getUserByToken(Token token) {
+    public User getUserByToken(Token token) throws DALException {
         Jedis connection = null;
         try {
             connection = redisConnector.getConnection();
@@ -85,16 +88,17 @@ public class AuthTokenRepositoryImpl implements AuthTokenRepository{
             String userId = connection.get(getKeyByToken(token));
             // TODO implement UserDao
             return userDao.getById(UUID.fromString(userId));
-        } catch (RuntimeException ex) {
-            ex.printStackTrace();
+        } catch (Exception ex) {
+            DALException dalException = new DALException(ex.getMessage());
+            dalException.setStackTrace(ex.getStackTrace());
+            throw dalException;
         } finally {
             closeConnection(connection);
         }
-        return null;
     }
 
     @Override
-    public Token update(Token token) {
+    public Token update(Token token) throws DALException {
         Jedis connection = null;
         try {
             connection = redisConnector.getConnection();
@@ -106,24 +110,27 @@ public class AuthTokenRepositoryImpl implements AuthTokenRepository{
             connection.setex(key, Long.valueOf(DEFAULT_EXPIRATION), user.getId().toString());
 
             return this.getTokenByUUID(token.getToken());
-        } catch (RuntimeException ex) {
-            ex.printStackTrace();
+        } catch (Exception ex) {
+            DALException dalException = new DALException(ex.getMessage());
+            dalException.setStackTrace(ex.getStackTrace());
+            throw dalException;
         }
         finally {
             closeConnection(connection);
         }
-        return null;
     }
 
     @Override
-    public void delete(Token token) {
+    public void delete(Token token) throws DALException {
         Jedis connection = null;
         try {
             connection = redisConnector.getConnection();
 
             connection.del(getKeyByToken(token));
-        } catch (RuntimeException ex) {
-            ex.printStackTrace();
+        } catch (Exception ex) {
+            DALException dalException = new DALException(ex.getMessage());
+            dalException.setStackTrace(ex.getStackTrace());
+            throw dalException;
         } finally {
             closeConnection(connection);
         }

--- a/src/main/java/com/cemonan/blog/service/AuthTokenService.java
+++ b/src/main/java/com/cemonan/blog/service/AuthTokenService.java
@@ -2,10 +2,11 @@ package com.cemonan.blog.service;
 
 import com.cemonan.blog.domain.Token;
 import com.cemonan.blog.domain.User;
+import com.cemonan.blog.exception.DALException;
 
 public interface AuthTokenService {
     Token getAuthUsersToken();
     User getAuthUser();
-    Token create(User user);
-    Token extendTokensExpiration(Token token);
+    Token create(User user) throws DALException;
+    Token extendTokensExpiration(Token token) throws DALException;
 }

--- a/src/main/java/com/cemonan/blog/service/AuthTokenServiceImpl.java
+++ b/src/main/java/com/cemonan/blog/service/AuthTokenServiceImpl.java
@@ -2,6 +2,7 @@ package com.cemonan.blog.service;
 
 import com.cemonan.blog.domain.Token;
 import com.cemonan.blog.domain.User;
+import com.cemonan.blog.exception.DALException;
 import com.cemonan.blog.repository.AuthTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,12 +39,12 @@ public class AuthTokenServiceImpl implements AuthTokenService {
     }
 
     @Override
-    public Token create(User user) {
+    public Token create(User user) throws DALException {
         return authTokenRepository.create(user);
     }
 
     @Override
-    public Token extendTokensExpiration(Token token) {
+    public Token extendTokensExpiration(Token token) throws DALException {
         token.setExpiresAt(Instant.now().getEpochSecond() + Long.valueOf(DEFAULT_EXPIRATION));
         return authTokenRepository.update(token);
     }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,18 @@
+{
+  "properties": [
+    {
+      "name": "redis.host",
+      "type": "java.lang.String",
+      "description": "Redis host"
+    },
+    {
+      "name": "redis.port",
+      "type": "java.lang.String",
+      "description": "Redis port number"
+    },
+    {
+      "name": "token.expires.after.seconds",
+      "type": "java.lang.String",
+      "description": "Default expire time for auth tokens in seconds"
+    }
+  ] }

--- a/src/test/java/com/cemonan/blog/AuthTokenServiceIntegrationTests.java
+++ b/src/test/java/com/cemonan/blog/AuthTokenServiceIntegrationTests.java
@@ -59,7 +59,7 @@ public class AuthTokenServiceIntegrationTests {
     }
 
     @Test
-    void testExtendExpirationTimeOfToken() {
+    void testExtendExpirationTimeOfToken() throws DALException {
         Token token = null;
         try {
             token = tokenFactory.create();

--- a/src/test/java/com/cemonan/blog/AuthTokenServiceIntegrationTests.java
+++ b/src/test/java/com/cemonan/blog/AuthTokenServiceIntegrationTests.java
@@ -2,6 +2,7 @@ package com.cemonan.blog;
 
 import com.cemonan.blog.domain.Token;
 import com.cemonan.blog.domain.User;
+import com.cemonan.blog.exception.DALException;
 import com.cemonan.blog.factory.TokenFactory;
 import com.cemonan.blog.factory.UserFactory;
 import com.cemonan.blog.service.AuthTokenService;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 import java.time.Instant;
 
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @SpringBootTest
@@ -34,7 +36,13 @@ public class AuthTokenServiceIntegrationTests {
 
     @Test
     void testCreateToken() {
-        Token token = tokenFactory.create();
+        Token token = null;
+        try {
+            token = tokenFactory.create();
+        } catch (DALException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
 
         assertThat(token).isNotNull();
         assertThat(token.getToken()).isNotNull();
@@ -52,7 +60,13 @@ public class AuthTokenServiceIntegrationTests {
 
     @Test
     void testExtendExpirationTimeOfToken() {
-        Token token = tokenFactory.create();
+        Token token = null;
+        try {
+            token = tokenFactory.create();
+        } catch (DALException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
 
         Token extendedToken = authTokenService.extendTokensExpiration(token);
 

--- a/src/test/java/com/cemonan/blog/AuthTokenServiceIntegrationTests.java
+++ b/src/test/java/com/cemonan/blog/AuthTokenServiceIntegrationTests.java
@@ -59,7 +59,7 @@ public class AuthTokenServiceIntegrationTests {
     }
 
     @Test
-    void testExtendExpirationTimeOfToken() throws DALException {
+    void testExtendExpirationTimeOfToken() {
         Token token = null;
         try {
             token = tokenFactory.create();
@@ -68,7 +68,13 @@ public class AuthTokenServiceIntegrationTests {
             fail(e.getMessage());
         }
 
-        Token extendedToken = authTokenService.extendTokensExpiration(token);
+        Token extendedToken = null;
+        try {
+            extendedToken = authTokenService.extendTokensExpiration(token);
+        } catch (DALException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
 
         assertThat(extendedToken.getExpiresAt()).isGreaterThan(token.getExpiresAt());
 


### PR DESCRIPTION
Data Access Layer components should not be catching exceptions, instead, exceptions should be translated at the data access layer and should be catched at top most layer of the application hierarchy.

Type migration for custom exception types: Because of the fact that all RuntimeExceptions and it's sub-classes are considered as unchecked exception types of Java, I've updated all the custom exception's base classes as Exception instead of RuntimeException.